### PR TITLE
Check that there are no path separators in GitHub API results.

### DIFF
--- a/internal/dropbox.go
+++ b/internal/dropbox.go
@@ -33,7 +33,8 @@ func (r *Backup) UploadMeta() error {
 	if err != nil {
 		return err
 	}
-	file := fmt.Sprintf("%s/%s/github2dropbox/meta.json", r.BackupDir, r.self.GetLogin())
+	file := fmt.Sprintf("%s/%s/github2dropbox/meta.json", r.BackupDir,
+		sanitizedFilePath(r.self.GetLogin()))
 	if err = os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
 		return err
 	}

--- a/internal/helper.go
+++ b/internal/helper.go
@@ -1,12 +1,40 @@
 package internal
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
+
+// Check if a string is safe for substituting in a path.  If the
+// string has substrings like ../ in it, it's not safe.  Check for
+// OS-specific separator and the forward slash.  The code uses forward
+// slashes before final substitution with filepath.FromSlash.  If
+// we're getting unsafe strings, things have gone wrong, just panic.
+// If the subpath had no separators, return the string.
+func sanitizedFilePath(subpath string) string {
+	if strings.Contains(subpath, fmt.Sprintf("%c", os.PathSeparator)) {
+		panic(fmt.Sprintf("Unsafe result returned from github API: %s", subpath))
+	}
+
+	// Also check for a forward slash
+	if strings.Contains(subpath, "/") {
+		panic(fmt.Sprintf("Unsafe result returned from github API: %s", subpath))
+	}
+
+	return subpath
+}
+
+// Replace all separator characters in a string
+// This replaces both OS-specific file path separators and foward slashes.
+func replaceSeparatorsFilePath(path string, osPathSeparator rune, replacement string) string {
+	path = strings.ReplaceAll(path, fmt.Sprintf("%c", osPathSeparator), replacement)
+	return strings.ReplaceAll(path, "/", replacement)
+}
 
 func runCmd(cmd string, args []string) error {
 	pwd, _ := os.Getwd()

--- a/internal/helper_test.go
+++ b/internal/helper_test.go
@@ -1,0 +1,70 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Test the case when the file path contains forward slashes.
+func TestSanitizedFilePathWithForwardSlashesPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code should panic with forward slashes")
+		}
+	}()
+
+	test_path := "directory/subdirectory/file.txt"
+
+	sanitizedFilePath(test_path)
+}
+
+// Test the case when the file path contains OS specific separators.
+// This is redundant and may be testing the same situation as above.
+// But the code explicitly uses forward slashes until the final path
+// is built.
+func TestSanitizedFilePathPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code should panic with file separators")
+		}
+	}()
+
+	test_path := filepath.Join("directory", "subdirectory", "file.txt")
+
+	sanitizedFilePath(test_path)
+}
+
+// Test that a file path with no separators works.
+func TestSanitizedFilePathWorks(t *testing.T) {
+	test_path := filepath.Join("file.txt")
+
+	result := sanitizedFilePath(test_path)
+
+	if result != "file.txt" {
+		t.Error("Expected file.txt got", result)
+	}
+}
+
+// Test that replacing forward slashes with a replacement character
+// works.
+func TestReplaceSeparatorsFilePathWithForwardSlashesWorks(t *testing.T) {
+	result := replaceSeparatorsFilePath("directory/file.txt", os.PathSeparator, "_")
+
+	if result != "directory_file.txt" {
+		t.Error("Expected directory_file.txt got", result)
+	}
+}
+
+// Test that replacing OS-specific separator with a replacement
+// character works.  This exercises the tests on the supported system
+// when it's run on them.
+func TestReplaceSeparatorsFilePathWithOSSeparatorsWorks(t *testing.T) {
+	test_string := fmt.Sprintf("directory%cfile.txt", os.PathSeparator)
+	result := replaceSeparatorsFilePath(test_string, os.PathSeparator, "_")
+
+	if result != "directory_file.txt" {
+		t.Error("Expected directory_file.txt got", result)
+	}
+}

--- a/internal/run.go
+++ b/internal/run.go
@@ -90,7 +90,7 @@ func (r *Backup) internalSaveRepoExt(repo *github.Repository, enableRepoGit, iss
 
 	if enableRepoGit {
 		func() {
-			repoPath := fmt.Sprintf("/tmp/%s", repo.GetName())
+			repoPath := fmt.Sprintf("/tmp/%s", sanitizedFilePath(repo.GetName()))
 			cloneURL := fmt.Sprintf("https://git:%s@github.com/%s.git", r.GithubToken, repo.GetFullName())
 
 			// clone

--- a/internal/save.go
+++ b/internal/save.go
@@ -5,41 +5,40 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/google/go-github/v42/github"
 )
 
 func (r *Backup) repoJsonPath(repo *github.Repository) string {
-	return fmt.Sprintf("%s/%s/repo/%s/%s.json", r.BackupDir, r.self.GetLogin(), repo.GetName(), repo.GetName())
+	return fmt.Sprintf("%s/%s/repo/%s/%s.json", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(repo.GetName()), sanitizedFilePath(repo.GetName()))
 }
 
 func (r *Backup) repoGitZipPath(repo *github.Repository) string {
-	return fmt.Sprintf("%s/%s/repo/%s/%s.git.zip", r.BackupDir, r.self.GetLogin(), repo.GetName(), repo.GetName())
+	return fmt.Sprintf("%s/%s/repo/%s/%s.git.zip", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(repo.GetName()), sanitizedFilePath(repo.GetName()))
 }
 
 func (r *Backup) repoIssueJsonPath(repo *github.Repository, issue *github.Issue) string {
-	return fmt.Sprintf("%s/%s/repo/%s/issue/%d/%d.json", r.BackupDir, r.self.GetLogin(), repo.GetName(), issue.GetID(), issue.GetID())
+	return fmt.Sprintf("%s/%s/repo/%s/issue/%d/%d.json", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(repo.GetName()), issue.GetID(), issue.GetID())
 }
 
 func (r *Backup) repoIssueCommentJsonPath(repo *github.Repository, issue *github.Issue, comment *github.IssueComment) string {
-	return fmt.Sprintf("%s/%s/repo/%s/issue/%d/comment/%d.json", r.BackupDir, r.self.GetLogin(), repo.GetName(), issue.GetID(), comment.GetID())
+	return fmt.Sprintf("%s/%s/repo/%s/issue/%d/comment/%d.json", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(repo.GetName()), issue.GetID(), comment.GetID())
 }
 
 func (r *Backup) starJsonPath(star *github.StarredRepository) string {
-	return fmt.Sprintf("%s/%s/star/%s.json", r.BackupDir, r.self.GetLogin(), strings.ReplaceAll(star.GetRepository().GetFullName(), "/", "_"))
+	return fmt.Sprintf("%s/%s/star/%s.json", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), replaceSeparatorsFilePath(star.GetRepository().GetFullName(), os.PathSeparator, "_"))
 }
 
 func (r *Backup) followerJsonPath(user *github.User) string {
-	return fmt.Sprintf("%s/%s/follower/%s.json", r.BackupDir, r.self.GetLogin(), user.GetLogin())
+	return fmt.Sprintf("%s/%s/follower/%s.json", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(user.GetLogin()))
 }
 
 func (r *Backup) followingJsonPath(user *github.User) string {
-	return fmt.Sprintf("%s/%s/following/%s.json", r.BackupDir, r.self.GetLogin(), user.GetLogin())
+	return fmt.Sprintf("%s/%s/following/%s.json", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(user.GetLogin()))
 }
 
 func (r *Backup) gistJsonPath(data *github.Gist) string {
-	return fmt.Sprintf("%s/%s/gist/%s.json", r.BackupDir, r.self.GetLogin(), data.GetID())
+	return fmt.Sprintf("%s/%s/gist/%s.json", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(data.GetID()))
 }
 
 func getPathBaseName(path string) string {
@@ -49,7 +48,7 @@ func getPathBaseName(path string) string {
 }
 
 func (r *Backup) repoZipPath(repo *github.Repository) string {
-	return fmt.Sprintf("%s/%s/repo/%s/repo.zip", r.BackupDir, r.self.GetLogin(), repo.GetName())
+	return fmt.Sprintf("%s/%s/repo/%s/repo.zip", r.BackupDir, sanitizedFilePath(r.self.GetLogin()), sanitizedFilePath(repo.GetName()))
 }
 
 func (r *Backup) SaveRepoZip(repo *github.Repository) {

--- a/internal/state.go
+++ b/internal/state.go
@@ -89,7 +89,8 @@ func (r *Backup) setProcessedRecentlyByTitle(title, name string) {
 }
 
 func (r *Backup) metaPath() string {
-	return fmt.Sprintf("%s/%s/github2dropbox/meta.json", r.BackupDir, r.self.GetLogin())
+	return fmt.Sprintf("%s/%s/github2dropbox/meta.json", r.BackupDir,
+		sanitizedFilePath(r.self.GetLogin()))
 }
 
 func (r *Backup) loadMeta() *Meta {


### PR DESCRIPTION
Check that there are no path separators in GitHub API results.
Add tests for the checks.

This is a PR for [Platform-independent file path separator fixes](https://github.com/chyroc/github2dropbox/issues/2).

I believe it checks for all the cases where you're doing string interpolation into a path.  There's a small test file also included that should test the new functions.

replaceSeparatorsFilePath is redundant checking for a "/" and platform-dependent separator.

If you want to rename the functions, or change the panic message, that's cool.

Thanks
